### PR TITLE
Fixing kaniko

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ spec:
      }
       container(name: 'kaniko', shell: '/busybox/sh') {
       sh 'ls /workspace/opt/app/shared/*'
-       sh 'cp /workspace/opt/app/shared/* /workspace/'
+       sh 'cp -r /workspace/opt/app/shared/* /workspace/'
        sh 'pwd'
        sh 'ulimit -n 10000'
        sh '/kaniko/executor -f Dockerfile --destination=docker.ultimaengineering.io/search-and-sip-api:latest'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,6 @@ spec:
       PATH = "/busybox:/kaniko:$PATH"
      }
       container(name: 'kaniko', shell: '/busybox/sh') {
-      sh 'ls /workspace/opt/app/shared/*'
        sh 'cp -r /workspace/opt/app/shared/* /workspace/'
        sh 'pwd'
        sh 'ulimit -n 10000'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,7 @@ spec:
       PATH = "/busybox:/kaniko:$PATH"
      }
       container(name: 'kaniko', shell: '/busybox/sh') {
+      sh 'ls /workspace/opt/app/shared/*'
        sh 'cp /workspace/opt/app/shared/* /workspace/'
        sh 'pwd'
        sh 'ulimit -n 10000'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,8 @@ spec:
       name: sharedvolume
   volumes:
     - name: sharedvolume
-      emptyDir: {}
+      persistentVolumeClaim:
+        claimName: sharedvolume
 """
 ) {
    node(POD_LABEL) {


### PR DESCRIPTION
This adds a persistent Volume claim needed for HA kub config. 
the -r to cp is to cover what may exist as a .lost_and_found folder. 